### PR TITLE
use rez api

### DIFF
--- a/rez-cook.py
+++ b/rez-cook.py
@@ -375,6 +375,10 @@ if __name__ == "__main__":
         # install_prefix path is not in rez's packages path.
         os.environ["REZ_PACKAGES_PATH"] = os.pathsep.join(packages_path)
 
+    # Make sure the recipes path is removed from packages_path.
+    # Else, if recipes path is in packages path, recipes that have a baked variant will be flagged as cooked.
+    packages_path.remove(RECIPES_PATH)
+
     # Early check to see if the requested recipe exists.
     recipe_request = PackageRequest(args.package)
     it = iter_packages(recipe_request.name,

--- a/rez-cook.py
+++ b/rez-cook.py
@@ -377,7 +377,8 @@ if __name__ == "__main__":
 
     # Make sure the recipes path is removed from packages_path.
     # Else, if recipes path is in packages path, recipes that have a baked variant will be flagged as cooked.
-    packages_path.remove(RECIPES_PATH)
+    if RECIPES_PATH in packages_path:
+        packages_path.remove(RECIPES_PATH)
 
     # Early check to see if the requested recipe exists.
     recipe_request = PackageRequest(args.package)

--- a/rez-cook.py
+++ b/rez-cook.py
@@ -445,7 +445,7 @@ if __name__ == "__main__":
             # This package is not required to run the built recipe we want to cook.
             # Useful when you want to constrain to vfxrp for example.
             continue
-        if Path(rec.repository.location) == recipes_path:
+        if Path(rec.repository.location) == recipes_path.readlink():
             possible_recipes[rec.name] = rec
         else:
             packages_without_recipe[rec.name] = rec

--- a/rez-cook.py
+++ b/rez-cook.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 
 import rez.config
 from package_list import PackageList
-from rez.build_process import BuildType, create_build_process
+from rez.build_process import create_build_process
 from rez.build_system import create_build_system
 from rez.exceptions import BuildContextResolveError
 from rez.package_search import ResourceSearchResult
@@ -445,7 +445,10 @@ if __name__ == "__main__":
             # This package is not required to run the built recipe we want to cook.
             # Useful when you want to constrain to vfxrp for example.
             continue
-        if Path(rec.repository.location) == recipes_path.readlink():
+        real_recipes_path = recipes_path
+        if recipes_path.is_symlink():
+            real_recipes_path = recipes_path.readlink()
+        if Path(rec.repository.location) == real_recipes_path:
             possible_recipes[rec.name] = rec
         else:
             packages_without_recipe[rec.name] = rec


### PR DESCRIPTION
Hello,

This is the PR I spoke to you about, that changes some code to use rez api.
I was able to compile multiple variants of USD successfully using this new version.

The tool behaviour is a bit different with this new code.

Since it uses rez api, the tool uses rez config's `packages_path`. You're not limited to the `install_prefix` directory anymore for dependency resolution.
If not specified, the `install_prefix` is now the local_packages_path from rez config.
You don't have to specifiy every constraints anymore, rez-cook will just get the highest possible version available that satisfies all the other constraints.
You can use rez request syntax for the recipe and constraints args.
The cooked variant uses pinned versions. For example, cooking USD:
Before:
`usd-22.08/platform-windows/arch-AMD64/vs-2022/cfg-release/boost-1.79.0/tbb/openexr-2.4|3.1.2+/ocio-2.2.0/oiio/python-3.9.12/ptex/osd`
After:
`usd-22.08\platform-windows\arch-AMD64\vs-2022\cfg-release\boost-1.79.0\tbb-2020.3\openexr-3.1.5\ocio-2.2.0\oiio-2.3.16.0\python-3.9.12\ptex-2.4.1\osd-3.4.4`

I tested as best as I could but there might be some bugs. I couldn't test on linux, would like to know if it works correctly over there :)
Feel free to give me any feedback.

Some commands to test things out:
Build usd with vfxrp-2022: `rez python .\rez-cook.py --prefix D:\rez-cooked-packages -d usd -c vfxrp-2022`
Try to build usd with vfxrp-2022 and python-3.7: `rez python .\rez-cook.py --prefix D:\rez-cooked-packages -d usd -c vfxrp-2022 python-3.7`
That should output an error:
```
[ERROR] Failed to resolve context: ['vfxrp-2022', 'python-3.7', 'usd']
[ERROR] The following package conflicts occurred: (python-3.9 <--!--> python==3.7.9)
[ERROR] Resolve paths starting from initial requests to conflict:
  vfxrp-2022 --> [vfxrp==2022 --> python-3.9
  python-3.7 --> [python==3.7.9
  usd --> usd --> python-3.9
```